### PR TITLE
use `date` field instead of `created_at` for timestamp

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -111,7 +111,7 @@ PlasmoidItem {
                     var _glucose = Units.getUnitAwareValue(entry.sgv, units);
                     valArray.push(_glucose);
 
-                    var date = new Date(entry.created_at);
+                    var date = new Date(entry.date);
                     var paddedMinute = Utils.padTo2Digits(date.getMinutes());
 
                     if (i++ % 4 == 0) {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -15,7 +15,7 @@
         "Icon": "applications-other",
         "Id": "org.kde.plasma.nightscoutwidget",
         "Name": "Nightscout Widget",
-        "Version": "2.3.1",
+        "Version": "2.3.2",
         "Website": "https://github.com/woernsn/nightscout-widget-kde",
         "BugReportUrl": "https://github.com/woernsn/nightscout-widget-kde/issues"
     },


### PR DESCRIPTION
The `date` field is the Unix epoch for the entry. It represents the same time as `created_at` but also available in other NightScout installations which might have another version. This should fix #8.